### PR TITLE
fix n+1-queries issue adding includes

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes:#1

Score.all was replaced with Score.includes(:user) in scores_controller.rb

The issue has been fixed collecting the data in one query.

**Before**
<img width="848" alt="n+1-queries-before" src="https://user-images.githubusercontent.com/96296162/149164552-9c256535-53d8-4072-828c-571618dda212.png">

**After**
<img width="891" alt="n+1-queries-after" src="https://user-images.githubusercontent.com/96296162/149164595-195f7cf4-88ff-4c70-b5e4-62199c24313b.png">

